### PR TITLE
Add tests for should_include_file

### DIFF
--- a/tests/test_should_include_file.py
+++ b/tests/test_should_include_file.py
@@ -1,0 +1,27 @@
+import pathlib
+
+from concat_files import should_include_file
+
+
+def test_inclusion_with_include_set():
+    path = pathlib.Path('example.txt')
+    include = {'txt', 'md'}
+    assert should_include_file(path, include, None) is True
+
+
+def test_exclusion_with_exclude_set():
+    path = pathlib.Path('example.log')
+    exclude = {'log', 'tmp'}
+    assert should_include_file(path, None, exclude) is False
+
+
+def test_include_and_exclude_sets():
+    include = {'txt', 'md'}
+    exclude = {'md'}
+    path_md = pathlib.Path('doc.md')
+    path_txt = pathlib.Path('doc.txt')
+
+    # File extension present in both include and exclude -> excluded
+    assert should_include_file(path_md, include, exclude) is False
+    # File extension only in include -> included
+    assert should_include_file(path_txt, include, exclude) is True


### PR DESCRIPTION
## Summary
- add tests for the `should_include_file` helper
- ensure test package exists for pytest discovery

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*