### PR TITLE
Handle duplicate paths in concat_files

### DIFF
--- a/README
+++ b/README
@@ -7,7 +7,8 @@
 - **Directory structure header**: Lists only the files that will be concatenated, in a simple tree-like view.  
 - **File delimiters**: Each file’s content is bounded by lines indicating the start and end of that file.  
 - **Recursive traversal**: Use the `-r` (or `--recursive`) option to traverse directories deeply.  
-- **Flexible extension filtering**: `--include` and `--exclude` options let you easily decide which file types to process.  
+- **Flexible extension filtering**: `--include` and `--exclude` options let you easily decide which file types to process.
+- **Duplicate removal**: The script automatically deduplicates files collected from the provided paths.
 - **STDOUT by default**: By default, the concatenated result is written to standard output (great for using shell redirection). Use `-o` to write to a file.
 
 ## Requirements

--- a/concat_files.py
+++ b/concat_files.py
@@ -205,8 +205,10 @@ def main():
     all_files = []
     for file_list in file_dict.values():
         all_files.extend(file_list)
-    # Sort them by path just for consistency
-    all_files = sorted(all_files, key=lambda x: str(x))
+
+    # Remove duplicates (same file may appear under multiple paths) and
+    # sort the result for consistent ordering
+    all_files = sorted(set(all_files), key=lambda x: str(x))
 
     # 2. Open output destination (file or stdout)
     if args.output:


### PR DESCRIPTION
## Summary
- deduplicate the list of files gathered for concatenation
- mention duplicate removal in the README

## Testing
- `python3 -m py_compile concat_files.py`